### PR TITLE
Upgrade TypeScript and modernize practices

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "parcel-bundler": "^1.11.0",
     "sourcegraph": "^23.0.0",
     "tslint": "^5.15.0",
-    "typescript": "^3.4.2"
+    "typescript": "^3.7.4"
   },
   "dependencies": {
     "localforage": "^1.7.3",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -19,7 +19,7 @@ export class CachedMap<K extends string, V> {
     /**
      * @param id The unique ID of this map to distinguish it from other items in the cache.
      */
-    constructor(private id: string) {}
+    constructor(private readonly id: string) {}
 
     private getFullKey(key: K): string {
         return `${this.id}__${key}`
@@ -52,7 +52,7 @@ export class CachedAsyncValue<V> {
     /**
      * @param id The unique ID of this value to distinguish it from other items in the cache.
      */
-    constructor(private id: string, private compute: () => Promise<V>) {}
+    constructor(private readonly id: string, private readonly compute: () => Promise<V>) {}
 
     private async computeAndStore(): Promise<void> {
         this.promise = this.compute()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,10 +4993,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.2.tgz#9ed4e6475d906f589200193be056f5913caed481"
-  integrity sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A==
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- Use nullish coalescing, prefer readonly, and other TypeScript eslint fixes
- Upgrade TypeScript to a version that definitely supports these new features