### PR TITLE
chore(deps): upgrade rxjs from 6.x to 7.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
   "dependencies": {
     "localforage": "^1.7.3",
     "lodash": "^4.17.11",
-    "rxjs": "^6.4.0"
+    "rxjs": "7.3.8"
   }
 }


### PR DESCRIPTION
Upgrades `rxjs` from 6.x to **7.3.8**.

> ⚠️ rxjs 7 has breaking changes — please review the [migration guide](https://rxjs.dev/guide/v6/migration) before merging.

[_Created by Sourcegraph batch change `ajay.sridhar/dfb8c718-7b23-41de-8fe9-5679a4f3b264`._](https://sourcegraph.sourcegraph.com/users/ajay.sridhar/batch-changes/dfb8c718-7b23-41de-8fe9-5679a4f3b264)